### PR TITLE
chore(eslint): do not sort export

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,13 +12,12 @@
     "plugin:import/typescript"
   ],
   "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint", "import", "sort-exports"],
+  "plugins": ["@typescript-eslint", "import"],
   "rules": {
     "import/order": [
       "error",
       { "newlines-between": "always", "alphabetize": { "order": "asc" } }
     ],
-    "sort-exports/sort-exports": ["error", { "sortDir": "asc" }],
     "sort-imports": ["error", { "ignoreDeclarationSort": true }]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@typescript-eslint/parser": "^4.3.0",
         "eslint": "^7.11.0",
         "eslint-plugin-import": "^2.22.1",
-        "eslint-plugin-sort-exports": "^0.3.2",
         "jest": "^26.5.3",
         "prettier": "^2.1.2",
         "rimraf": "^3.0.2",
@@ -2998,12 +2997,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/eslint-plugin-sort-exports": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-sort-exports/-/eslint-plugin-sort-exports-0.3.2.tgz",
-      "integrity": "sha512-9wx4oHU3M/jFbqhRtR6vcmcbKoNj++1bnSMjLmNCNza+nWpCjo3o5gFIUmTFxr4JBOD1QL9ONR8EE9T9Rf1COQ==",
-      "dev": true
     },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
@@ -11496,12 +11489,6 @@
           }
         }
       }
-    },
-    "eslint-plugin-sort-exports": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-sort-exports/-/eslint-plugin-sort-exports-0.3.2.tgz",
-      "integrity": "sha512-9wx4oHU3M/jFbqhRtR6vcmcbKoNj++1bnSMjLmNCNza+nWpCjo3o5gFIUmTFxr4JBOD1QL9ONR8EE9T9Rf1COQ==",
-      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "test": "jest --coverage",
     "watch": "rollup -cw"
   },
-  "dependencies": {},
   "devDependencies": {
     "@rollup/plugin-commonjs": "^15.1.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
@@ -31,7 +30,6 @@
     "@typescript-eslint/parser": "^4.3.0",
     "eslint": "^7.11.0",
     "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-sort-exports": "^0.3.2",
     "jest": "^26.5.3",
     "prettier": "^2.1.2",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
Functions and variables shouldn't be sorted in alphabetical order.
The following shouldn't give an error when linting.
export function B ...
export function A...